### PR TITLE
Convert hex-string sig to byte string sig.

### DIFF
--- a/[Project 1] Tutorial and Basic Mining.ipynb
+++ b/[Project 1] Tutorial and Basic Mining.ipynb
@@ -149,7 +149,7 @@
     "    sig_fname = \"sig{}.json\".format(i)\n",
     "    with open(sig_fname, \"r\") as sig_f:\n",
     "        data = json.loads(sig_f.readline())\n",
-    "        sig = data[\"sig\"]\n",
+    "        sig = bytes.fromhex(data[\"sig\"])\n",
     "        if verify(pk, MESSAGE, sig):\n",
     "            print(\"PASS\")\n",
     "        else:\n",


### PR DESCRIPTION
Shouldn't sig be converted byte string before being passed to verify function?
I have to do that conversion to pass the test for problem #5 in Part I.
sig = bytes.fromhex(data["sig"])